### PR TITLE
Fix aclpubcheck instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then, you can run all tools using the `clean.sh` script:
 Your cleaned paper and bib file will be saved to `"path/to/latex_arxiv"`. Be sure to check the logs for errors. If you additionally want to run `aclpubcheck`, convert your paper to a PDF and run:
 
 ```bash
-python aclpubcheck/formatchecker.py --paper_type [long|short|other] path/to/paper.pdf
+python ./aclpubcheck/aclpubcheck/formatchecker.py --paper_type [long|short|other] path/to/paper.pdf
 ```
 
 ## :memo: Notes, tips and tricks


### PR DESCRIPTION
Command to call `aclpubcheck` should point to `./aclpubcheck/aclpubcheck`, not `aclpubcheck`.